### PR TITLE
Master files to be used for view overrides 

### DIFF
--- a/com_dpfields/admin/views/fields/view.html.php
+++ b/com_dpfields/admin/views/fields/view.html.php
@@ -7,8 +7,6 @@
  */
 defined('_JEXEC') or die();
 
-JLoader::import('joomla.filesystem.file');
-
 class DPFieldsViewFields extends JViewLegacy
 {
 

--- a/com_dpfields/admin/views/fields/view.html.php
+++ b/com_dpfields/admin/views/fields/view.html.php
@@ -7,6 +7,8 @@
  */
 defined('_JEXEC') or die();
 
+JLoader::import('joomla.filesystem.file');
+
 class DPFieldsViewFields extends JViewLegacy
 {
 

--- a/com_dpfields/site/layouts/field/erender.php
+++ b/com_dpfields/site/layouts/field/erender.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package    DPFields
+ * @author     Digital Peak http://www.digital-peak.com
+ * @copyright  Copyright (C) 2015 - 2015 Digital Peak. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl.html GNU/GPL
+ */
+defined('_JEXEC') or die();
+
+	// Needed if we want to search for the file. Let's keep it simple for now
+	// JLoader::import('joomla.filesystem.path');
+
+	JLoader::import('joomla.filesystem.file');
+
+	$fields = $displayData['item']->dpfields ?: array();
+	if (!empty($displayData['fieldlist']))
+	{
+		$fieldlist = $displayData['fieldlist'];
+
+		foreach ($fieldlist as $field => $v)
+		{
+			if (!$v)
+			{
+				unset($fieldlist[$field]);
+			}
+		}
+	}
+	else
+	{
+		$fieldlist = $fields;
+	}
+
+	foreach ($fieldlist as $field => $v)
+	{
+		$field = (int) $field;
+		$label = $fields[$field]->title;
+		$value = $fields[$field]->value;
+
+		// We do not show any empty fields
+		if (! $value)
+		{
+			continue;
+		}
+
+		$class = '';
+		if (isset($fields[$field]->class))
+		{
+			$class = $fields[$field]->class;
+		}
+		$id = $fields[$field]->id;
+
+		//check if an individual override exists for this field
+
+		$rawPath  = 'efield' . (int) $id . '.php';
+		$fullpath = __FILE__;
+		$fullpath = str_replace('.php', '' , $fullpath );
+		//$fullpath = JPath::find($fullpath, $rawPath);
+		$sub_exists = JFile::exists($fullpath.'/'.$rawPath);
+
+		if ($sub_exists)
+		{
+			$basePath = JPATH_ROOT .'/components/com_dpfields/layouts';
+
+			echo JLayoutHelper::render('field.erender.efield'.(int) $id, array('field' => $fields[$field]),
+			$basePath, array(
+			'component' => 'com_content',
+			'client' => 0
+		));
+		}
+		else
+		{
+	?>
+
+	<dd class="dpfield-entry <?php echo $class;?>">
+		<span class="dpfield-label"><?php echo htmlentities($label);?>: </span>
+		<span class="dpfield-value"><?php echo $value;?></span>
+	</dd>
+
+  <?php
+		}
+	}
+  ?>

--- a/com_dpfields/site/layouts/field/erender/efield1.php
+++ b/com_dpfields/site/layouts/field/erender/efield1.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package    DPFields
+ * @author     Digital Peak http://www.digital-peak.com
+ * @copyright  Copyright (C) 2015 - 2015 Digital Peak. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl.html GNU/GPL
+ */
+defined('_JEXEC') or die();
+
+	$field = $displayData['field'] ?: array();
+
+	$label = $field->title;
+	$value = $field->value;
+
+	if (! $value)
+	{
+		return;
+	}
+		$class = '';
+		if (isset($field->class))
+		{
+			$class = $field->class;
+		}
+		$id = (int) $field->id;
+		?>
+
+	<div class="dpfield-entry <?php echo $class;?>">
+		<span class="dpfield-label"><?php echo htmlentities($label);?>: </span>
+		<span class="dpfield-value"><?php echo $value;?></span>
+	</div>

--- a/com_dpfields/site/layouts/field/example_override.php
+++ b/com_dpfields/site/layouts/field/example_override.php
@@ -1,0 +1,20 @@
+//Code example to be used in override views
+
+		<?php
+		$basePath = JPATH_ROOT .'/components/com_dpfields/layouts';
+
+		// Fields to output, false = no output, empty array = all fields
+		$fields = array
+		(
+			'87.my-field-87' => true,
+			'1.my-field-1' => false,
+			'5,my-field-2' => true
+		);
+
+		echo JLayoutHelper::render('field.erender', array('item' => $this->item, 'fieldlist' => $fields),
+		$basePath, array(
+		'component' => 'com_content',
+		'client' => 0
+		));
+		?>
+	


### PR DESCRIPTION
Hi there,
I added those 3 files to DPfields.
e.g. 
1. Copy the article view default.php to /your/template/html/com_content/article/default.php
2. Edit that file and add code as in the example file. Be aware of the fieldlist. You should add all fields you have available for articles with id.title. Order them as you like. Set the value to true if it should be shown here, false iif not. You can duplicate it for other positions in the default.php
3. Copy the erender.php file to  /your/template/html/layouts/com_content/field/erender.php You should be ok leaving this as is for now. You can chane it if you need othe html tags.
4. Copy efield1.php to  /your/template/html/layouts/com_content/field/erender/efield1.php Change the name of this file to efield# whwrw # is the id of a field you want to test giving a specific JLayout.

Nice?
