### PR TITLE
Prevent fatal error if there is no active menu

### DIFF
--- a/plg_system_dpfields/dpfields.php
+++ b/plg_system_dpfields/dpfields.php
@@ -380,7 +380,11 @@ class PlgSystemDPFields extends JPlugin
 		{
 			$activeMenu = JFactory::getApplication()->getMenu()->getActive();
 			$params = $activeMenu->params;
-			$data->catid = $params->get('catid');
+			
+			if (isset($params))
+			{
+				$data->catid = $params->get('catid');
+			}
 		}
 
 		$component = $parts[0];


### PR DESCRIPTION
#### Simple check to prevent fatal error
##### Testing

Try to log in with wrong credentials. Before patch you get a fatal error
