### PR TITLE
Fix: Call to a member function get() on null

### DIFF
--- a/plg_system_dpfields/dpfields.php
+++ b/plg_system_dpfields/dpfields.php
@@ -674,7 +674,7 @@ class PlgSystemDPFields extends JPlugin
 			}
 		}
 
-		if (is_string($params))
+		if (!$params instanceof Registry)
 		{
 			$params = new Registry($params);
 		}


### PR DESCRIPTION
In use with com_contacts $params is null.
Changed check to validate $params variable is instance of Registry.