### PR TITLE
Allow raw content by onContentPrepare

### DIFF
--- a/plg_system_dpfields/dpfields.php
+++ b/plg_system_dpfields/dpfields.php
@@ -823,7 +823,7 @@ class PlgSystemDPFields extends JPlugin
 				Mustache_Autoloader::register();
 
 				$m = new Mustache_Engine();
-				$output = $m->render('{{#dpfields}}' . substr($item->text, $start, $end - $start) . '{{/dpfields}}',
+				$output = $m->render('{{#dpfields}}{' . substr($item->text, $start, $end - $start) . '}{{/dpfields}}',
 						array(
 								'dpfields' => $contextFields
 						));


### PR DESCRIPTION
This is more a suggestion then a fix.

For example if you insert an gallery field in the article with the editor button the HTML code shows as text only.
Mustache needs three brackets to render raw HTML.

I know {{value}} can be changed to {{{value}}} but a normal user don't know this and will ask every time.
Maybe it make more sense to add an checkbox or something to the editor button. Or must be defined per field type raw is required.